### PR TITLE
[CODE] add csv download

### DIFF
--- a/src/react-app/components/SimulationDrawer.tsx
+++ b/src/react-app/components/SimulationDrawer.tsx
@@ -6,7 +6,7 @@ import {
     useSpring, 
 } from '@react-spring/web';
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { LineChart } from '@mui/x-charts/LineChart';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -29,6 +29,9 @@ function SimulationDrawer() {
     const data = useStore((store) => store.simulationData);
     const speciesInfo = useStore((store) => store.visualNodes);
 
+    const showCsvDownloadButton = useStore((store) => store.showCsvDownloadButton);
+    const setShowCsvDownloadButton = useStore((store) => store.setShowCsvDownloadButton);
+
     const setSimDrawerOpen = useStore((store) => store.setSimDrawerOpen);
     const onSimulate = useStore((store) => store.fetchSimulationData);
 
@@ -45,8 +48,6 @@ function SimulationDrawer() {
     const [rotateSpring, rotateApi] = useSpring(() => ({
         from: { rotate: 0, y: '0px' },
     }));
-
-    const [showCsvDownloadButton, setShowCsvDownloadButton] = useState(false);
 
     // When the outer drawer is clicked, spring open / closed
     const handleClick = () => {

--- a/src/react-app/components/SimulationDrawer.tsx
+++ b/src/react-app/components/SimulationDrawer.tsx
@@ -6,18 +6,20 @@ import {
     useSpring, 
 } from '@react-spring/web';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { LineChart } from '@mui/x-charts/LineChart';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import useStore from '../stores/store';
 
 import { 
-    ChevronDownIcon
+    ChevronDownIcon,
+    DownloadIcon
 } from "@radix-ui/react-icons";
 
 import '../styles/index.css';
 import '../styles/Simulation.css';
+import { TooltipContent, TooltipRoot, TooltipTrigger } from './Tooltips';
 
 
 function SimulationDrawer() {
@@ -44,14 +46,24 @@ function SimulationDrawer() {
         from: { rotate: 0, y: '0px' },
     }));
 
+    const [showCsvDownloadButton, setShowCsvDownloadButton] = useState(false);
+
     // When the outer drawer is clicked, spring open / closed
     const handleClick = () => {
+        if (open) {
+            setShowCsvDownloadButton(false);
+        }
 
         // Do animation
         api.start({
             from: { height: 90, width: 300 },
             to: { height: 500, width: 500 },
             reverse: open,
+            onRest: () => {
+                if (!open) {
+                    setShowCsvDownloadButton(true);
+                }
+            }
         });
 
         rotateApi.start({
@@ -70,6 +82,27 @@ function SimulationDrawer() {
             handleClick(); // Open the drawer if it's not already open
         }
         onSimulate(); // Outer call to run simulation
+    }
+
+    const handleCSVDownload = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        const headers = Object.keys(data[0]).map(key => keyToLabel[key] || key);
+        const values = data.map(d => {
+            return [...Object.keys(data[0]).map(key => String(d[key]))];
+        });
+
+        const concatArray = [headers].concat(values);
+        const csv = concatArray.map(a => a.join(",")).join("\n");
+        const blob = new Blob([csv], { type: "text/csv;charset=utf-8;"});
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+        link.href = url;
+        link.download = `simulate-data-${timestamp}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
     }
 
     // Construct legend for line chart!
@@ -124,36 +157,70 @@ function SimulationDrawer() {
         >
             <div>
             
-            {/* Big SIMULATE button */}
-            <button onClick={handleSimulate} className="SimulateButton">{buttonLabel}</button>
-        
-            <br />
-            <br />
-            <br />
+                {/* Big SIMULATE button */}
+                <button onClick={handleSimulate} className="SimulateButton">{buttonLabel}</button>
+            
+                <br />
+                <br />
+                <br />
 
-            {/* Our line chart */}
-            {open ? <ThemeProvider theme={chartTheme}> 
-            <LineChart
-                dataset={data}
-                xAxis={[
-                    { dataKey: 'time',
-                        valueFormatter: (value: number) => value.toString(),
-                        label: 'time',
-                    },
-                ]}
-                yAxis={[{ width: 50, label: 'concentration' }]}
-                series={Object.keys(keyToLabel).map((key) => ({
-                    dataKey: key,
-                    label: keyToLabel[key],
-                    color: colors[key],
-                    showMark: false,
-                }))}
-                height={300}
-                width={500}
-            />
-            </ThemeProvider> : null}
-
+                {/* Our line chart */}
+                {open ? <ThemeProvider theme={chartTheme}> 
+                    <LineChart
+                        dataset={data}
+                        xAxis={[
+                            { dataKey: 'time',
+                                valueFormatter: (value: number) => value.toString(),
+                                label: 'time',
+                            },
+                        ]}
+                        yAxis={[{ width: 50, label: 'concentration' }]}
+                        series={Object.keys(keyToLabel).map((key) => ({
+                            dataKey: key,
+                            label: keyToLabel[key],
+                            color: colors[key],
+                            showMark: false,
+                        }))}
+                        height={300}
+                        width={500}
+                    />
+                    </ThemeProvider> : null
+                }
             </div>
+
+            {/* CSV Download button */}
+            {showCsvDownloadButton ? 
+                <TooltipRoot>
+                    <TooltipTrigger>
+                        <button
+                            style={{
+                                position: "absolute",
+                                right: "8px",
+                                bottom: "8px",
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "4px",
+                                padding: "4px 8px",
+                                ...(simStatus === 2
+                                    ? { backgroundColor: "green" }
+                                    : { backgroundColor: "#cccccc", color: "#888888"}
+                                )
+                            }}
+                            disabled={ simStatus === 2 ? false : true }
+                            onClick={handleCSVDownload}
+                        >
+                            <DownloadIcon />Download CSV
+                        </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        { simStatus === 2 
+                            ? "Download the simulation data in CSV format!"
+                            : "No data to download yet!"
+                        }
+                    </TooltipContent>
+                </TooltipRoot>
+                : null
+            }
 
             {/* Close button to collapse drawer. */}
             <button 

--- a/src/react-app/components/SimulationDrawer.tsx
+++ b/src/react-app/components/SimulationDrawer.tsx
@@ -194,19 +194,12 @@ function SimulationDrawer() {
                 <TooltipRoot>
                     <TooltipTrigger>
                         <button
-                            style={{
-                                position: "absolute",
-                                right: "8px",
-                                bottom: "8px",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "4px",
-                                padding: "4px 8px",
-                                ...(simStatus === 2
-                                    ? { backgroundColor: "green" }
+                            className="DownloadButton"
+                            style={
+                                simStatus === 2
+                                    ? { backgroundColor: "#87F5A6" }
                                     : { backgroundColor: "#cccccc", color: "#888888"}
-                                )
-                            }}
+                            }
                             disabled={ simStatus === 2 ? false : true }
                             onClick={handleCSVDownload}
                         >

--- a/src/react-app/stores/store.ts
+++ b/src/react-app/stores/store.ts
@@ -133,6 +133,9 @@ type AppState = {
   rxnDrawerOpen: boolean;
   setRxnDrawerOpen: (open: boolean) => void;
 
+  showCsvDownloadButton: boolean;
+  setShowCsvDownloadButton: (open: boolean) => void;
+
   simulationStatus: number; // 0 = not started, 1 = running, 2 = complete, 3 = error
   simulationData: Array<Record<string, number>>;
   fetchSimulationData: () => void;
@@ -409,6 +412,10 @@ onEdgesChange: (changes) => {
     // Open the Reaction Editor Drawer
     rxnDrawerOpen: false,
     setRxnDrawerOpen: (open) => set({ rxnDrawerOpen: open }),
+
+    // Display the CSV download button in the simulation drawer
+    showCsvDownloadButton: false,
+    setShowCsvDownloadButton: (open) => set({ showCsvDownloadButton: open }),
 
     // Update the label of a given species in both species and visualNodes
     updateSpeciesLabel: (id, newLabel) => set((store) => ({

--- a/src/react-app/styles/Simulation.css
+++ b/src/react-app/styles/Simulation.css
@@ -66,6 +66,20 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
+.DownloadButton {
+	padding: 4px 8px;
+
+	color: #000000;
+
+	position: absolute;
+	right: 8px;
+	bottom: 8px;
+
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
 .SimulationCloseButton {
 	padding: 0px;
 	height: 2em;


### PR DESCRIPTION
Closes #72 

## 🤔 Section A - Description
This PR adds CSV download support for simulation results in `SimulationDrawer`.
   
- What changed
  - Added a `Download CSV` button with a download icon to the simulation drawer.
  - Styled the button to be green when `simulationStatus === 2` and gray otherwise.
  - Added tooltip text that changes based on whether simulation data is ready.
  - Converted `simulationData` into CSV output using species labels derived from the existing `keyToLabel` mapping.
  - Triggered a browser download for the generated CSV file.
  - Delayed rendering of the CSV button until the drawer open animation finishes so it does not appear before the drawer has expanded.
   
- Why
  - This lets users export simulation output for external analysis and graphing, which is the main goal of Issue #72.
   
- Anything reviewers should know
  - The change is contained to `src/react-app/components/SimulationDrawer.tsx`.
  - The CSV headers use the same label mapping already used by the chart legend so exported data is easier to read.

## ✅ Verification
<img width="1918" height="832" alt="image" src="https://github.com/user-attachments/assets/fb94509f-f929-49f5-8ef7-aa3cc132f9b3" />
<img width="1918" height="746" alt="image" src="https://github.com/user-attachments/assets/594110fa-51c2-4004-ac2e-fc50bb6f08d9" />
<img width="1918" height="811" alt="image" src="https://github.com/user-attachments/assets/0e5c37b0-c84f-404a-b06c-e16978bc53d3" />
<img width="1918" height="786" alt="image" src="https://github.com/user-attachments/assets/fa4e8e2d-676f-438d-bae8-bf5ad4f49a8d" />

[x] I ran this code locally and it does what the description says

## 🔎 Quick Self Check
- [ ] This PR is **one logical change**. (Big or architectural? Let's chat in an issue first before writing code 🙏)
- [x] No leftover dead code, debugging prints, or unused imports
- [x] Every import / API / dependency I reference actually exists and is already available
- [ ] Comments explain *why* not what, and the style matches the surrounding file.
- [x] I used existing functions and components where possible.
- [x] My style matches the surrounding code to the best of my ability
- [x] I could re-derive any non-obvious line if you asked me to

## 🔁 When we request changes

We review to make the code better, not to nitpick. We'd also love to help you grow as a contributor! 🌱 When we leave comments:

- **Please reply inline and update *this* PR.** Push new commits to the same branch.
- **Please don't close this and open a brand-new PR** with regenerated code. We lose the whole conversation that way, and it usually reintroduces the things we just fixed. Iterating in place is faster for both of us.

Thanks again for contributing, we're glad you're here!! 🎉


## 📜 BioBuilder Contributor License Agreement

I give Mark Stevens and BioBuilder permission to license my contributions on any terms they like. I am giving them this license in order to make it possible for them to accept my contributions into their project.

**_As far as the law allows, my contributions come as is, without any warranty or condition, and I will not be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**
